### PR TITLE
Support for multiple callback calls

### DIFF
--- a/paytrail/urls.py
+++ b/paytrail/urls.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2020 Data King Ltd
+# Copyright (c) 2014-2022 Data King Ltd
 # See LICENSE file for license details
 
 from django.urls import path
@@ -9,5 +9,4 @@ app_name = 'paytrail'
 urlpatterns = (
     path('success/', SuccessView.as_view(), name='success'),
     path('failure/', FailureView.as_view(), name='failure'),
-    path('notify/<token>/', notification, name='notification')
 )

--- a/paytrail/views.py
+++ b/paytrail/views.py
@@ -15,7 +15,7 @@ from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from oscar.apps.checkout.views import PaymentDetailsView as CorePaymentDetailsView
 from oscar.apps.payment import exceptions
-from oscar.apps.payment.models import Source, SourceType, Transaction
+from oscar.apps.payment.models import Source, SourceType
 from oscar.core.loading import get_model
 
 TEST_MERCHANT_ID = '375917'

--- a/paytrail/views.py
+++ b/paytrail/views.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from oscar.apps.checkout.views import PaymentDetailsView as CorePaymentDetailsView
 from oscar.apps.payment import exceptions

--- a/paytrail/views.py
+++ b/paytrail/views.py
@@ -329,9 +329,6 @@ def notification(request, token):
         except Transaction.DoesNotExist:
             # create new transaction by debit method
             source.debit(reference=transaction_id, status=status)
-
-        if not source.transactions.filter(reference=transaction_id).exists():
-            source.debit(reference=transaction_id)
     else:
         logger.error(
             'checkout-status was not ok: %s (transaction id: %s, order: %s)',
@@ -340,4 +337,4 @@ def notification(request, token):
             order,
         )
 
-    return HttpResponse('ok')
+    return HttpResponse()

--- a/paytrail/views.py
+++ b/paytrail/views.py
@@ -304,8 +304,8 @@ def notification(request, token):
 
     transaction_id = request.GET.get('checkout-transaction-id', None)
     if not transaction_id:
-        logger.error('checkout-transaction-id missing', code=400)
-        raise ValidationError
+        logger.error('checkout-transaction-id query parameter missing')
+        raise ValidationError('checkout-transaction-id missing', code=400)
 
     status = request.GET.get('checkout-status', None)
     if not status:

--- a/paytrail/views.py
+++ b/paytrail/views.py
@@ -316,7 +316,7 @@ def notification(request, token):
         # Payment source is created in SuccessView.
         # It is possible that this callback view is called before SuccessView
         # so source might not be available yet.
-        source = get_object_or_404(order.sources.all(), source_type=get_source_type())
+        source = get_object_or_404(order.sources, source_type=get_source_type())
 
         # check if transaction is already created
         try:

--- a/paytrail/views.py
+++ b/paytrail/views.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.signing import Signer
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from oscar.apps.checkout.views import PaymentDetailsView as CorePaymentDetailsView
 from oscar.apps.payment import exceptions
@@ -23,6 +23,7 @@ TEST_MERCHANT_ID = '375917'
 TEST_MERCHANT_SECRET = 'SAIPPUAKAUPPIAS'
 URL = 'https://services.paytrail.com/payments'
 
+Basket = get_model('basket', 'Basket')
 Order = get_model('order', 'Order')
 logger = logging.getLogger(__name__)
 signer = Signer()
@@ -270,7 +271,11 @@ class ReturnView(CorePaymentDetailsView):
 
     def get(self, request, *args, **kwargs):
         validate_signature(request.GET)
-        self.get_submitted_basket().thaw()
+        try:
+            self.get_submitted_basket().thaw()
+        except Basket.DoesNotExist:
+            # basket does not exist - who are you?
+            return redirect('/')
         return self.handle_place_order_submission(request)
 
 


### PR DESCRIPTION
* Paytrail can call callback URL multiple times (`notification` view)
* support for transaction status changes

Question: should `Source` be created in `notification` view? Wit this MR `notification` view returns 404 if user has not opened `SuccessView` yet and therefore `Source` object is not yet created.